### PR TITLE
[BAR-702][AK] prevent user from double click "Add Payment" button

### DIFF
--- a/src/app/core/components/payment-instruction/payment-instruction.component.html
+++ b/src/app/core/components/payment-instruction/payment-instruction.component.html
@@ -251,7 +251,7 @@
               </button>
             </div>
             <div class="button-grid__button">
-              <button class="button button-view" type="submit" id="instruction-submit">
+              <button class="button button-view" type="submit" id="instruction-submit" [disabled]="saveDisabled">
                 {{ (!loadedId) ? dictionary.buttonText : 'Save changes' }}
               </button>
             </div>

--- a/src/app/core/components/payment-instruction/payment-instruction.component.spec.ts
+++ b/src/app/core/components/payment-instruction/payment-instruction.component.spec.ts
@@ -12,7 +12,7 @@ import { ActivatedRoute, ParamMap, Router, RouterModule } from '@angular/router'
 import {UserService} from '../../../shared/services/user/user.service';
 import {PaymenttypeService} from '../../services/paymenttype/paymenttype.service';
 
-import {of} from 'rxjs';
+import {of, Observable} from 'rxjs';
 
 import {PaymentTypeServiceMock} from '../../test-mocks/payment-type.service.mock';
 import {UserServiceMock} from '../../test-mocks/user.service.mock';
@@ -285,5 +285,23 @@ describe('PaymentInstructionComponent', () => {
     expect(fixture.debugElement.nativeElement.textContent).not.toContain('Payer name');
     const button = fixture.debugElement.query(By.css('#instruction-submit'));
     expect(button.nativeElement.disabled).toBeFalsy();
+  });
+
+  it('after clicking the save button it should be disabled', async() => {
+    spyOn(paymentInstructionService, 'savePaymentInstruction').and.callFake(() => {
+      expect(component.saveDisabled).toBeTruthy();
+      return of({});
+    });
+    component.onSelectPaymentType(createCashPaymentType());
+    component.model = createPaymentInstruction();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const paymentTypeModel = new PaymentTypeModel();
+    paymentTypeModel.id = component.paymentTypeEnum$.getValue().CASH;
+    paymentTypeModel.name = 'Cash';
+
+    component.model.payment_type = paymentTypeModel;
+    component.onFormSubmission();
+    expect(component.saveDisabled).toBeFalsy();
   });
 });

--- a/src/app/core/components/payment-instruction/payment-instruction.component.ts
+++ b/src/app/core/components/payment-instruction/payment-instruction.component.ts
@@ -44,6 +44,7 @@ export class PaymentInstructionComponent implements OnInit {
   paymentTypes$: BehaviorSubject<IPaymentType[]> = new BehaviorSubject<IPaymentType[]>([]);
   paymentTypeEnum$: BehaviorSubject<PaymentTypeEnum> = new BehaviorSubject<PaymentTypeEnum>(new PaymentTypeEnum());
   dictionary = DEFAULT_DICTIONARY;
+  saveDisabled = false;
 
   constructor(
     private _paymentInstructionService: PaymentInstructionsService,
@@ -140,6 +141,7 @@ export class PaymentInstructionComponent implements OnInit {
   }
   // ------------------------------------------------------------------------------------------
   onFormSubmission(e?): void {
+    this.saveDisabled = true;
     if (e) {
       e.preventDefault();
     }
@@ -164,7 +166,7 @@ export class PaymentInstructionComponent implements OnInit {
           this.onFormSubmission();
         }
         this.paymentInstructionSuggestion = true;
-      }, console.log);
+      }, console.log, () => this.saveDisabled = false);
   }
 
   onRouteParams(params): void {


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [&#10004;] commit messages are meaningful and follow good commit message guidelines
- [&#10004;] README and other documentation has been updated / added (if needed)
- [&#10004;] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BAR-702


### Change description ###
This change disables the "Add payment" button and remains disabled until the remote request to the server finishes, after that it will be enabled regardless of the response


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
