### PR TITLE
Nightly build fix

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -59,6 +59,8 @@ withNightlyPipeline("nodejs", product, component) {
 
   afterAlways('build') {
     sh 'mkdir -p functional-output'
+
+    // Node 18 being picked up, temporary disabling build - will uncomment post Node 18 upgrade.
     sh 'yarn ng:build'
   }
   afterAlways('securityScan') {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Comment out yarn ng:build during night build as the commend is picking up Node 18 runtime when it should be using Node 14! This is only used to provide lastest mutation runtime code. Should be fine as a temporary measure.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
