### PR TITLE
PAY-6727 new stage for a11y

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -57,8 +57,13 @@ withPipeline("nodejs", product, component) {
       reportFiles          : "index.html",
       reportName           : 'Bar Web E2E functional tests result'
     ]
-    yarnBuilder.yarn('test:a11y')
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/functional/reports/**/*'
+  }
+
+  before('functionalTest:aat') {
+    stage('a11y') {
+      yarnBuilder.yarn('test:a11y')
+    }
   }
 
   afterAlways('functionalTest:aat') {

--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,7 @@
           },
           "configurations": {
             "production": {
-              "optimization": true,
+              "optimization": false,
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": false,

--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,7 @@
           },
           "configurations": {
             "production": {
-              "optimization": false,
+              "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": false,


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-6727


### Change description ###
a11y tests no longer have an application to run against because the helm uninstall has been run, following the functional tests endoing. Trying to create a new stage, or persisting the application.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
