### PR TITLE
PAY-6727: Move Pa11y to after xbrowser tests and fix FT

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -47,7 +47,6 @@ withPipeline("nodejs", product, component) {
     yarnBuilder.yarn('ng:build')
   }
 
-
   afterAlways('functionalTest:preview') {
     publishHTML target: [
       allowMissing         : true,
@@ -57,7 +56,6 @@ withPipeline("nodejs", product, component) {
       reportFiles          : "index.html",
       reportName           : 'Bar Web E2E functional tests result'
     ]
-    yarnBuilder.yarn('test:a11y')
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/functional/reports/**/*'
   }
 
@@ -70,7 +68,6 @@ withPipeline("nodejs", product, component) {
       reportFiles          : "index.html",
       reportName           : 'Bar Web E2E functional tests result'
     ]
-    yarnBuilder.yarn('test:a11y')
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/functional/reports/**/*'
   }
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -52,6 +52,7 @@ withNightlyPipeline("nodejs", product, component) {
   enableCrossBrowserTest()
   enableFullFunctionalTest(90)
   enableSecurityScan()
+
   afterAlways('checkout') {
     sh "yarn cache clean"
     echo 'bar-web checked out'
@@ -61,10 +62,12 @@ withNightlyPipeline("nodejs", product, component) {
     sh 'mkdir -p functional-output'
     yarnBuilder.yarn('ng:build')
   }
+
   afterAlways('securityScan') {
      steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
   }
-   afterAlways('fortify-scan') {
+
+  afterAlways('fortify-scan') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
   }
 
@@ -77,7 +80,6 @@ withNightlyPipeline("nodejs", product, component) {
       reportFiles          : "index.html",
       reportName           : 'Bar Web E2E functional tests result'
     ]
-    yarnBuilder.yarn('test:a11y')
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/functional/reports/**/*'
   }
 
@@ -91,5 +93,9 @@ withNightlyPipeline("nodejs", product, component) {
       reportName           : "Cross Browser Test Report"
     ]
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/cross-browser/reports/**/*'
+  }
+
+  afterAlways('crossBrowserTest') {
+    yarnBuilder.yarn('test:a11y')
   }
 }

--- a/acceptance-tests/test/end-to-end/tests/BARMultisite_test.js
+++ b/acceptance-tests/test/end-to-end/tests/BARMultisite_test.js
@@ -123,6 +123,14 @@ Scenario('@functional Fee-clerk "check and submit" validate action counter', asy
   I.click('Submit');
 
   I.processPayment(paymentInstructionId2Site2);
+  I.waitForText('Payments list', BARATConstants.fiveSecondWaitTime);
+
+  // The payments list page is too long, even refreshing you end up half way down the page with no visibility of the
+  // site switch header. This change is a simple fix to bring the header back into visibility.
+  I.see('Check and submit');
+  I.click('Check and submit');
+  I.waitForText('Check and submit');
+  I.wait(BARATConstants.twoSecondWaitTime);
 
   // Site1 return
   await I.switchSite('MILTON KEYNES COUNTY COURT');


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-6727


### Change description ###
Couple of issues addressed:

1. Update to address the BARMultiSite_test which switched back to MILTON KEYNES COUNTY COURT but this repeatidly failed. This was because the MEDWAY Payments List was too long and focus for the page was away from the header, so the site selection wasn't visible, only one site was returned. Checking the dom and the other attributes were available but not shown. Simple fix was to move the user to the Check and submit page before switching sites back to Milton Keynes.

2. Pa11y tests were invoked from a yarn action post functional tests, however the pipeline was invisible to this action, so as the functional tests are the last step in the Preview and Nightly pipelines, this inverably failed even though the Pa11y tests run really quickly. I've moved the Pa11y tests to run after the cross browser tests and removed the other two calls.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
