### PR TITLE
PAY-7489 dependency update for cve

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "lodash": "^4.17.15",
     "moment": "2.29.4",
     "moment-timezone": "^0.5.35",
+    "nanoid": "^3.3.8",
     "ngx-cookie-service": "^16.0.1",
     "node-cache": "^4.2.0",
     "npm-run-all": "^4.1.5",
@@ -218,7 +219,8 @@
     "serve-static": "^1.16.2",
     "body-parser": "1.20.3",
     "cookie": "^0.7.0",
-    "cross-spawn": "7.0.6"
+    "cross-spawn": "7.0.6",
+    "nanoid": "^3.3.8"
   },
   "packageManager": "yarn@3.6.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6578,6 +6578,7 @@ __metadata:
     mochawesome: ^3.0.2
     moment: 2.29.4
     moment-timezone: ^0.5.35
+    nanoid: ^3.3.8
     ngx-cookie-service: ^16.0.1
     nock: ^10.0.0
     node-cache: ^4.2.0
@@ -15932,12 +15933,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.6":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
+"nanoid@npm:^3.3.8":
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: d36c427e530713e4ac6567d488b489a36582ef89da1d6d4e3b87eded11eb10d7042a877958c6f104929809b2ab0bafa17652b076cdf84324aa75b30b722204f2
+  checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Jira link
See [PAY-7489]https://tools.hmcts.net/jira/browse/PAY-7489
### Change description
npm nanoid version updated to 3.3.8

### Testing done

yarn install and built with no issues.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
